### PR TITLE
Add missing comma in Stoutlogic Text Field Type

### DIFF
--- a/Field-Types.md
+++ b/Field-Types.md
@@ -5,7 +5,7 @@
 ### Text 
 ```php
 $fields
-    ->addText('text_field' [
+    ->addText('text_field', [
         'label' => 'Text Field',
         'instructions' => '',
         'required' => 0,


### PR DESCRIPTION
In the Stoutlogic ACF Builder documentation, a comma was missing after the field name in the configuration. This commit fixes the issue by adding the necessary comma for proper configuration.