### PR TITLE
Update repeater field options

### DIFF
--- a/Repeater.md
+++ b/Repeater.md
@@ -56,6 +56,7 @@ $slider
             'max' => 7,
             'button_label' => 'Add Slide',
             'layout' => 'block',
+            'collapsed' => 'title',
           ])
         ->addText('title')
         ->addWysiwyg('content');


### PR DESCRIPTION
There is a lack of documentation for the repeater field settings on the official ACF website. I had to create a repeater field from the UI and export it as Json to get the name of the option for specifying the field that is shown when a row is collapsed.